### PR TITLE
List of tasks with fixmes

### DIFF
--- a/catatom2osm.py
+++ b/catatom2osm.py
@@ -203,7 +203,7 @@ class CatAtom2Osm:
                         self.delete_shp(fn, False)
                         self.merge_address(task_osm, self.address_osm)
                         report.address_stats(task_osm)
-                        report.cons_stats(task_osm)
+                        report.cons_stats(task_osm, label)
                         fn = os.path.join('tasks', label + '.osm')
                         self.write_osm(task_osm, fn, compress=True)
                         report.osm_stats(task_osm)
@@ -279,6 +279,10 @@ class CatAtom2Osm:
     def end_messages(self):
         if report.fixme_stats():
             log.warning(_("Check %d fixme tags"), report.fixme_count)
+            filename = 'review.txt'
+            with open(os.path.join(self.path, filename), "w") as fo:
+                fo.write(setup.eol.join(map(str, report.get_tasks_with_fixmes())))
+                log.info(_("Generated '%s'"), filename)
         if self.options.tasks or self.options.building:
             report.cons_end_stats()
         if self.options.tasks or self.options.building or self.options.address:

--- a/report.py
+++ b/report.py
@@ -130,6 +130,7 @@ class Report(object):
             'rss': lambda v: locale.format_string('%.2f GB', v, True),
             'vms': lambda v: locale.format_string('%.2f GB', v, True),
         }
+        self.tasks_with_fixmes = set()
 
     def __setattr__(self, key, value):
         if key in ['values', 'titles', 'groups']:
@@ -153,7 +154,7 @@ class Report(object):
                 if not 'entrance' in el.tags:
                     self.inc('out_address_building')
 
-    def cons_stats(self, data):
+    def cons_stats(self, data, task_label=None):
         for el in data.elements:
             if 'leisure' in el.tags and el.tags['leisure'] == 'swimming_pool':
                 self.inc('out_pools')
@@ -167,6 +168,11 @@ class Report(object):
                 self.inc('out_features')
             if 'fixme' in el.tags:
                 self.fixme_counter[el.tags['fixme']] += 1
+                if task_label is not None:
+                    self.tasks_with_fixmes.add(task_label)
+
+    def get_tasks_with_fixmes(self):
+        return sorted(self.tasks_with_fixmes)
 
     def osm_stats(self, data):
         self.inc('nodes', len(data.nodes))


### PR DESCRIPTION
Refers to issue 66 in @javiersanp repository.
This records the tasks' labels rather than the requested file name. The workaround to get the file name is simple, but this implementation seems cleaner to me.
Format of the output file is just a label in each line.