### PR TITLE
Development

### DIFF
--- a/hgwnames.py
+++ b/hgwnames.py
@@ -24,10 +24,10 @@ def parse(name):
     for (i, word) in enumerate(re.split('[ ]+', name.strip())):
         nude_word = re.sub('^\(|\)$', '', word) # Remove enclosing parenthesis
         if i == 0:
-            try:
-                new_word = setup.highway_types[word]
-            except KeyError:
-                new_word = word
+            if word in setup.excluded_types:
+                return ""
+            else:
+                new_word = setup.highway_types.get(word, word)
         elif nude_word in setup.lowcase_words: # Articles
             new_word = word.lower()
         elif "'" in word[1:-1]: # Articles with aphostrope
@@ -55,13 +55,14 @@ def match(name, choices):
         name (str): String to look for
         choices (list): Iterable with choices
     """
-    if fuzz:
+    parsed_name = parse(name)
+    if fuzz and parsed_name:
         normalized = [normalize(c) for c in choices]
-        matching = process.extractOne(normalize(parse(name)), 
+        matching = process.extractOne(normalize(parsed_name), 
             normalized, scorer=fuzz.token_sort_ratio)
         if matching and matching[1] > MATCH_THR:
             return choices[normalized.index(matching[0])]
-    return parse(name)
+    return parsed_name
 
 def dsmatch(name, dataset, fn):
     """
@@ -75,6 +76,8 @@ def dsmatch(name, dataset, fn):
     Returns:
         First element with the maximun fuzzy ratio.
     """
+    if not name:
+        return ""
     max_ratio = 0
     matching = None
     for e in dataset:

--- a/hgwnames.py
+++ b/hgwnames.py
@@ -76,12 +76,10 @@ def dsmatch(name, dataset, fn):
     Returns:
         First element with the maximun fuzzy ratio.
     """
-    if not name:
-        return ""
     max_ratio = 0
     matching = None
     for e in dataset:
-        if fuzz:
+        if fuzz and name:
             ratio = fuzz.token_sort_ratio(normalize(name), normalize(fn(e)))
             if ratio > max_ratio:
                 max_ratio = ratio

--- a/setup.py
+++ b/setup.py
@@ -183,6 +183,9 @@ highway_types = { # Dictionary for default 'highway_types.csv'
     'SC': u'Sector',
 }
 
+# List of highway types not to be parsed
+excluded_types = ['DS', 'ER']
+
 # List of highway types to translate as place addresses
 place_types = [
 	'Agregado', 'Aldea', u'Área', 'Barrio', 'Barranco', u'Cañada', 'Colegio', 


### PR DESCRIPTION
Refers to issue 65 in @javiersanp repository.
As requested, parse(name) returns an empty string for the excluded street types.
notes:
· match and dsmatch check if the name string is empty before running any fuzzywuzzy method, to prevent it from throwing "all comparisons will have score 0" warnings.
· parse was running twice per match for non matching names, so I extracted it to parsed_name.