### PR TITLE
Mover la lógica del clip al fichero Layer

### DIFF
--- a/catatom2osm/layer.py
+++ b/catatom2osm/layer.py
@@ -605,9 +605,22 @@ class BaseLayer(QgsVectorLayer):
         return pbar
 
     def remove_outside_features(self, layer):
-        """Remove from self any feature not contained in layer features."""
-        # TODO: implementar
-        pass
+        """Remove from self any feature not contained in geometry features."""
+        split = Geometry.merge_adjacent_features([f for f in layer.getFeatures()])
+
+        crs_transform = ggs2coordinate_transform(layer.crs(), self.crs())
+        split.transform(crs_transform)
+        
+        to_clean = []
+        fcount = self.featureCount()
+        for feat in self.getFeatures():
+            geom = feat.geometry()
+            if not split.contains(geom):
+                to_clean.append(feat.id())
+
+        if len(to_clean):
+            self.writer.deleteFeatures(to_clean)
+            log.debug(_("Removed %d of %d features."), len(to_clean), fcount)
 
 class PolygonLayer(BaseLayer):
     """Base class for polygon layers"""

--- a/catatom2osm/layer.py
+++ b/catatom2osm/layer.py
@@ -621,7 +621,7 @@ class BaseLayer(QgsVectorLayer):
 
         if len(to_clean):
             self.writer.deleteFeatures(to_clean)
-            log.debug(_("Removed %d of %d features."), len(to_clean), fcount)
+            log.debug(_("%s: Removed %d of %d features."), self.name(), len(to_clean), fcount)
 
 class PolygonLayer(BaseLayer):
     """Base class for polygon layers"""

--- a/catatom2osm/layer.py
+++ b/catatom2osm/layer.py
@@ -608,8 +608,9 @@ class BaseLayer(QgsVectorLayer):
         """Remove from self any feature not contained in geometry features."""
         split = Geometry.merge_adjacent_features([f for f in layer.getFeatures()])
 
-        crs_transform = ggs2coordinate_transform(layer.crs(), self.crs())
-        split.transform(crs_transform)
+        if layer.crs() != self.crs():
+            crs_transform = ggs2coordinate_transform(layer.crs(), self.crs())
+            split.transform(crs_transform)
         
         to_clean = []
         fcount = self.featureCount()


### PR DESCRIPTION
1. Se ha eliminado la dependencia inicial del CRS como argumento del split_zoning
2. Prefiero obtener la geometría haciendo uso de `Geometry.merge_adjacent_features` por si hay que cambiar el CRS
3. Aplicar transformación de manera condicional
4. He probado con geojson que contengan lineas o puntos
5. Se podría eliminar la función split_zoning, e incluirlo directamente bajo el options
6. Tengo un error del método  `Geometry.merge_adjacent_features` para el geojson siguiente:

```json
{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-5.441156029701233,42.080172799623455],[-5.442346930503845,42.07954769902057],[-5.441113114356995,42.07840100165121],[-5.439616441726685,42.07945612325587],[-5.441011190414429,42.080292244897784],[-5.441156029701233,42.080172799623455]]]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-5.439777374267578,42.0806864127078]}}]}
```

Aunque tiene un punto, no falla por eso, sino porque `[f for f in layer.getFeatures()]` no le devuelve nada. No entiendo el problema.