### PR TITLE
Define sólo la major version de python en pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: 22.1.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3
 -   repo: https://github.com/pycqa/isort
     rev: 5.5.2
     hooks:


### PR DESCRIPTION
Mientras trabajaba en #103 me he topado con este error, que me salía al intentar hacer un commit (después de instalar `pre-commit` y ejectuar `pre-commit install`):

```
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/python', '-mvirtualenv', '/home/alejandro/.cache/pre-commit/repokafxsgtp/py_env-python3.8', '-p', 'python3.8')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.8'
    
stderr: (none)
Check the log at /home/alejandro/.cache/pre-commit/pre-commit.log
```

Según https://github.com/pre-commit/pre-commit/issues/1375#issuecomment-603906811, la mejor solución es usar `python3` en vez de `python3.8`. Efectivamente, con ese cambio ya no me salta el error.