### PR TITLE
Anota en el log valores de configuración inválidos

### DIFF
--- a/catatom2osm/config.py
+++ b/catatom2osm/config.py
@@ -739,8 +739,12 @@ def get_user_config(path):
     try:
         with open(path, "r") as config_file:
             user_config = yaml.safe_load(config_file)
-        for key in default_user_config.keys() & user_config.keys():
-            globals()[key] = user_config[key]
+        default_keys = default_user_config.keys()
+        for key in user_config.keys():
+            if key in default_keys:
+                globals()[key] = user_config[key]
+            else:
+                log.warning(_("Config key '%s' is not valid") % key)
     except yaml.YAMLError as e:
         msg = _("Can't read '%s'") % path
         raise (CatConfigError(msg + ": " + str(e)))

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -35,7 +35,8 @@ class TestConfig(unittest.TestCase):
         m_open.assert_not_called()
         self.assertIn("exists. Delete", m_print.call_args_list[0][0][0])
 
-    def test_get_user_config(self):
+    @mock.patch("catatom2osm.config.logging")
+    def test_get_user_config(self, m_logging):
         data = "warning_min_area: 1234\n"
         data += "foo: bar\n"
         m_open = mock.mock_open(read_data=data)
@@ -44,6 +45,9 @@ class TestConfig(unittest.TestCase):
         m_open.assert_called_once_with("taz", "r")
         self.assertEqual(config.warning_min_area, 1234)
         self.assertFalse(hasattr(config, "foo"))
+        m_logging.getLogger().warning.assert_called_once_with(
+            "Config key 'foo' is not valid"
+        )
 
     def test_get_user_config_error(self):
         data = "foo: ["


### PR DESCRIPTION
En vez de iterar sobre la intersección de los conjuntos de claves de los diccionarios `default_user_config` y el `user_config`, itera sobre las claves del diccionario `user_config`. Con cada clave, si está en `default_user_config`, actúa como hasta ahora y sobreescribe la variable; si no, añade un warning al log.

He modificado uno de los tests para comprobar que se llama a la función `warning` con el mensaje especificado.

Lo que no tengo claro es cómo traducir las cadenas de texto. Si me indicas cómo hacerlo, añado un nuevo commit a la rama con la traducción.

Fixes #106 